### PR TITLE
chore: bump actions/checkout to v6

### DIFF
--- a/.github/workflows/validate-gentx.yml
+++ b/.github/workflows/validate-gentx.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Update checkout action to the latest major version